### PR TITLE
Fix Flaky Async Behavior

### DIFF
--- a/src/main/java/com/laserfiche/api/client/httphandlers/OAuthClientCredentialsHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/OAuthClientCredentialsHandler.java
@@ -25,12 +25,9 @@ public class OAuthClientCredentialsHandler implements HttpRequestHandler{
         BeforeSendResult result = new BeforeSendResult();
         if (accessToken == null || accessToken.equals("")) {
             future = client.getAccessTokenFromServicePrincipal(spKey, accessKey);
-            future.thenApply(tokenResponse -> {
+            return future.thenApply(tokenResponse -> {
                 accessToken = tokenResponse.getAccessToken();
                 request.headers().append("Authorization", accessToken);
-                return null;
-            });
-            return future.thenApply(tokenResponse -> {
                 result.setRegionalDomain(accessKey.getDomain());
                 return result;
             });


### PR DESCRIPTION
The problem was we have two `future.thenApply(...)` meaning that we are returning two `CompletableFuture<T>`. This is fine but since we can only return one of them, if we later wait for the returned one to finish, there's no guarantee that the other one will also finish.

The flaky part: sometimes both finishes (such as the case for the integration test). Other times, only the returned on finishes (the case in the repository client library).

The solution is to group the two futures into one.

Fix #9 