### PR TITLE
Better Error Message and Avoid Deprecated APIs

### DIFF
--- a/src/main/java/com/laserfiche/api/client/model/AccessKey.java
+++ b/src/main/java/com/laserfiche/api/client/model/AccessKey.java
@@ -36,7 +36,7 @@ public class AccessKey {
         try {
             accessKey = mapper.readValue(accessKeyStr, AccessKey.class);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(String.format("Invalid access key.%nDetail:%s", e));
         }
         return accessKey;
     }

--- a/src/main/java/com/laserfiche/api/client/model/AccessKey.java
+++ b/src/main/java/com/laserfiche/api/client/model/AccessKey.java
@@ -2,6 +2,7 @@ package com.laserfiche.api.client.model;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.nimbusds.jose.jwk.JWK;
 
@@ -19,13 +20,14 @@ public class AccessKey {
 
     public static AccessKey createFromBase64EncodedAccessKey(String base64EncodedAccessKey) {
         if (mapper == null) {
-            mapper = new ObjectMapper();
-            mapper.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
-
             SimpleModule module = new SimpleModule();
             module.addDeserializer(JWK.class, new JwkDeserializer());
 
-            mapper.registerModule(module);
+            mapper = JsonMapper
+                    .builder()
+                    .disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)
+                    .addModule(module)
+                    .build();
         }
         base64EncodedAccessKey = base64EncodedAccessKey.trim();
         if (base64EncodedAccessKey.length() == 0) {

--- a/src/main/java/com/laserfiche/api/client/model/AccessKey.java
+++ b/src/main/java/com/laserfiche/api/client/model/AccessKey.java
@@ -38,7 +38,7 @@ public class AccessKey {
         try {
             accessKey = mapper.readValue(accessKeyStr, AccessKey.class);
         } catch (IOException e) {
-            throw new RuntimeException(String.format("Invalid access key.%nDetail:%s", e));
+            throw new RuntimeException("Invalid access key. Detail: " + e, e);
         }
         return accessKey;
     }


### PR DESCRIPTION
1. We provide better error message when the AccessKey cannot be created from the given string.
2. We avoid deprecated Jackson APIs.