### PR TITLE
refactor jwk accessors and update integration tests

### DIFF
--- a/src/main/java/com/laserfiche/api/client/model/AccessKey.java
+++ b/src/main/java/com/laserfiche/api/client/model/AccessKey.java
@@ -42,11 +42,11 @@ public class AccessKey {
         this.clientId = clientId;
     }
 
-    public JWK getJWK() {
+    public JWK getJwk() {
         return jwk;
     }
 
-    public void setJWK(JWK jwk) {
+    public void setJwk(JWK jwk) {
         this.jwk = jwk;
     }
 

--- a/src/main/java/com/laserfiche/api/client/oauth/OAuthUtil.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/OAuthUtil.java
@@ -36,7 +36,7 @@ public class OAuthUtil {
      */
     public static String createBearer(String spKey, AccessKey accessKey) {
         // Prepare JWK
-        ECKey jwk = accessKey.getJWK().toECKey();
+        ECKey jwk = accessKey.getJwk().toECKey();
 
         // Prepare JWS
         JWSObject jws = createJws(jwk, spKey, accessKey);

--- a/src/test/java/com/laserfiche/api/client/unit/AccessKeyTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/AccessKeyTest.java
@@ -36,8 +36,10 @@ class AccessKeyTest {
     @ParameterizedTest
     @ValueSource(strings = {" ", "", "\n", "\t"})
     void CreateFromBase64EncodedAccessKey_IllegalArgumentExceptionThrown(String base64EncodedAccessKey) {
-        assertThrows(IllegalArgumentException.class, () -> AccessKey.createFromBase64EncodedAccessKey(base64EncodedAccessKey));
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> AccessKey.createFromBase64EncodedAccessKey(base64EncodedAccessKey));
+        assertThrows(IllegalArgumentException.class,
+                () -> AccessKey.createFromBase64EncodedAccessKey(base64EncodedAccessKey));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> AccessKey.createFromBase64EncodedAccessKey(base64EncodedAccessKey));
         assertEquals("Input cannot be empty or null", exception.getMessage());
     }
 
@@ -45,7 +47,11 @@ class AccessKeyTest {
     @ValueSource(strings = {"YXNkYXNkYXNkYXNkYWQ=", "你好你好", "\uD83D\uDE00 \uD83D\uDE03 \uD83D\uDE04 \uD83D\uDE01"})
     void CreateFromBase64EncodedAccessKey_RunTimeExceptionThrown(String base64EncodedAccessKey) {
         assertThrows(RuntimeException.class, () -> AccessKey.createFromBase64EncodedAccessKey(base64EncodedAccessKey));
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> AccessKey.createFromBase64EncodedAccessKey(base64EncodedAccessKey));
-        assertTrue(Objects.equals(exception.getMessage(), "Illegal base64 character 3f") || exception.getMessage().contains("Unrecognized token") || Objects.equals(exception.getMessage(), "Input cannot be empty or null"));
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> AccessKey.createFromBase64EncodedAccessKey(base64EncodedAccessKey));
+        assertTrue(Objects.equals(exception.getMessage(), "Illegal base64 character 3f") || exception
+                .getMessage()
+                .contains("Unrecognized token") || Objects.equals(exception.getMessage(),
+                "Input cannot be empty or null"));
     }
 }

--- a/src/test/java/com/laserfiche/api/client/unit/AccessKeyTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/AccessKeyTest.java
@@ -20,7 +20,7 @@ class AccessKeyTest {
         expectedDecodedAccessKey.setCustomerId("7215189634");
         expectedDecodedAccessKey.setDomain("laserfiche.ca");
         String jwkJson = "{\"kty\": \"EC\",\"crv\": \"P-256\", \"use\": \"sig\", \"kid\": \"_pk_xM5VCqEND6OULr_DNYs-GegAUJwLBP9lyFenAMh\",\"x\": \"6oZILnV7ytZPB1uz2P47_a_Ymko7SmTNuGpnzl20iCs\", \"y\": \"ZQorDAQqhY6ojHSV_dpzXxbKI0eKljZbeGQKYDfPHsE\", \"d\": \"B1oAZHCPP2Ic03fhRuXVKQpEpQdM5bqqbK7iKQU-4Uh\"}";
-        expectedDecodedAccessKey.setJWK(JWK.parse(jwkJson));
+        expectedDecodedAccessKey.setJwk(JWK.parse(jwkJson));
         String base64EncodedAccessKey = "eyJjdXN0b21lcklkIjoiNzIxNTE4OTYzNCIsImRvbWFpbiI6Imxhc2VyZmljaGUuY2EiLCJjbGllbnRJZCI6IlY1Z3FIeGt6aWhaS2RRVFNjNkRGWW5rZCIsImp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwidXNlIjoic2lnIiwia2lkIjoiX3BrX3hNNVZDcUVORDZPVUxyX0ROWXMtR2VnQVVKd0xCUDlseUZlbkFNaCIsIngiOiI2b1pJTG5WN3l0WlBCMXV6MlA0N19hX1lta283U21UTnVHcG56bDIwaUNzIiwieSI6IlpRb3JEQVFxaFk2b2pIU1ZfZHB6WHhiS0kwZUtsalpiZUdRS1lEZlBIc0UiLCJkIjoiQjFvQVpIQ1BQMkljMDNmaFJ1WFZLUXBFcFFkTTVicXFiSzdpS1FVLTRVaCJ9fQ==";
 
         // Act
@@ -28,7 +28,7 @@ class AccessKeyTest {
 
         // Assert
         assertEquals(expectedDecodedAccessKey.getDomain(), decodedAccessKey.getDomain());
-        assertEquals(expectedDecodedAccessKey.getJWK(), decodedAccessKey.getJWK());
+        assertEquals(expectedDecodedAccessKey.getJwk(), decodedAccessKey.getJwk());
         assertEquals(expectedDecodedAccessKey.getClientId(), decodedAccessKey.getClientId());
         assertEquals(expectedDecodedAccessKey.getCustomerId(), decodedAccessKey.getCustomerId());
     }


### PR DESCRIPTION
In order to keep private field/accessor naming convention consistent
- change getJWK() to getJwk()
- change setJWK() to setJwk() 
- update integration tests