### PR TITLE
Fix passphrase not used and hanging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>


### PR DESCRIPTION
When one release a jar, one needs to sign it. maven-gpg-plugin is used to do that. But the 1.5 version of it has a bug which makes it not reading the passphrase of the private key in the settings.xml (`%username%/m2/settings.xml`) so it will ask for it every time. But in order to also run the pipeline in GitHub, we set it to not promot the user for passphrase. Therefore, the end result is that when releasing from one's computer, the pipeline hangs forever.

1.6 of the plugin fixes that issue so we upgrade to 1.6 in this PR.