### PR TITLE
Add AutoCloseable

### DIFF
--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
@@ -15,7 +15,8 @@ public interface TokenClient extends AutoCloseable {
     CompletableFuture<SessionKeyInfo> createAccessToken(String repoId, CreateConnectionRequest body);
 
     /**
-     * Overrides close() in AutoCloseable as no meaningful exception can be handled.
+     * Since the underlying resource (the HTTP client) won't throw any exception during its close() invocation.
+     * We override the signature of the close() to not include any checked exception.
      */
     @Override
     void close();

--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
@@ -5,7 +5,7 @@ import com.laserfiche.api.client.model.SessionKeyInfo;
 
 import java.util.concurrent.CompletableFuture;
 
-public interface TokenClient {
+public interface TokenClient extends AutoCloseable {
 
     /**
      * @param repoId Repository name
@@ -13,4 +13,10 @@ public interface TokenClient {
      * @return Create an access token successfully.
      */
     CompletableFuture<SessionKeyInfo> createAccessToken(String repoId, CreateConnectionRequest body);
+
+    /**
+     * Overrides close() in AutoCloseable as no meaningful exception can be handled.
+     */
+    @Override
+    void close();
 }

--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClientImpl.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClientImpl.java
@@ -6,7 +6,6 @@ import com.laserfiche.api.client.model.CreateConnectionRequest;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.api.client.model.SessionKeyInfo;
 import com.laserfiche.api.client.oauth.OAuthClient;
-import kong.unirest.Unirest;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -24,7 +23,7 @@ public class TokenClientImpl extends OAuthClient implements TokenClient {
     public CompletableFuture<SessionKeyInfo> createAccessToken(String repoId, CreateConnectionRequest body) {
         Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"},
                 new Object[]{repoId});
-        return Unirest
+        return httpClient
                 .post(baseUrl + "/v1/Repositories/{repoId}/Token")
                 .routeParam(pathParameters)
                 .header("Accept", "application/json")
@@ -74,5 +73,4 @@ public class TokenClientImpl extends OAuthClient implements TokenClient {
                     }
                 });
     }
-
 }

--- a/src/main/java/com/laserfiche/api/client/deserialization/JwkDeserializer.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/JwkDeserializer.java
@@ -1,4 +1,4 @@
-package com.laserfiche.api.client.model;
+package com.laserfiche.api.client.deserialization;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
@@ -19,7 +19,8 @@ public interface HttpRequestHandler extends AutoCloseable {
     CompletableFuture<Boolean> afterSendAsync(Response response);
 
     /**
-     * Overrides close() in AutoCloseable as no meaningful exception can be handled.
+     * Since the underlying resource (the HTTP client) won't throw any exception during its close() invocation.
+     * We override the signature of the close() to not include any checked exception.
      */
     @Override
     void close();

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
@@ -2,7 +2,7 @@ package com.laserfiche.api.client.httphandlers;
 
 import java.util.concurrent.CompletableFuture;
 
-public interface HttpRequestHandler {
+public interface HttpRequestHandler extends AutoCloseable {
 
     /**
      * Invoked before an HTTP request with the request message and cancellation token.
@@ -17,4 +17,10 @@ public interface HttpRequestHandler {
      * @return True if the request should be retried.
      */
     CompletableFuture<Boolean> afterSendAsync(Response response);
+
+    /**
+     * Overrides close() in AutoCloseable as no meaningful exception can be handled.
+     */
+    @Override
+    void close();
 }

--- a/src/main/java/com/laserfiche/api/client/httphandlers/OAuthClientCredentialsHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/OAuthClientCredentialsHandler.java
@@ -49,4 +49,9 @@ public class OAuthClientCredentialsHandler implements HttpRequestHandler {
         }
         return CompletableFuture.completedFuture(shouldRetry);
     }
+
+    @Override
+    public void close() {
+        client.close();
+    }
 }

--- a/src/main/java/com/laserfiche/api/client/httphandlers/UsernamePasswordHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/UsernamePasswordHandler.java
@@ -70,4 +70,9 @@ public class UsernamePasswordHandler implements HttpRequestHandler {
         }
         return CompletableFuture.completedFuture(shouldRetry);
     }
+
+    @Override
+    public void close() {
+        client.close();
+    }
 }

--- a/src/main/java/com/laserfiche/api/client/model/AccessKey.java
+++ b/src/main/java/com/laserfiche/api/client/model/AccessKey.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.laserfiche.api.client.deserialization.JwkDeserializer;
 import com.nimbusds.jose.jwk.JWK;
 
 import java.io.IOException;

--- a/src/main/java/com/laserfiche/api/client/oauth/OAuthClient.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/OAuthClient.java
@@ -10,17 +10,20 @@ import com.laserfiche.api.client.deserialization.TokenClientObjectMapper;
 import kong.unirest.Header;
 import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
+import kong.unirest.UnirestInstance;
 import org.threeten.bp.OffsetDateTime;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class OAuthClient {
+public class OAuthClient implements AutoCloseable {
     protected ObjectMapper objectMapper;
+    protected final UnirestInstance httpClient;
 
     protected OAuthClient() {
-        Unirest
+        httpClient = Unirest.spawnInstance();
+        httpClient
                 .config()
                 .setObjectMapper(new TokenClientObjectMapper());
         SimpleModule module = new SimpleModule();
@@ -57,5 +60,10 @@ public class OAuthClient {
             }
         }
         return paramKeyValuePairs;
+    }
+
+    @Override
+    public void close() {
+        httpClient.close();
     }
 }

--- a/src/main/java/com/laserfiche/api/client/oauth/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/TokenClient.java
@@ -5,7 +5,7 @@ import com.laserfiche.api.client.model.GetAccessTokenResponse;
 
 import java.util.concurrent.CompletableFuture;
 
-public interface TokenClient {
+public interface TokenClient extends AutoCloseable {
     /**
      * Gets an OAuth access token given a Laserfiche cloud service principal key and an OAuth service application access key.
      *
@@ -36,4 +36,10 @@ public interface TokenClient {
      * @return A response that contains an access token
      */
     CompletableFuture<GetAccessTokenResponse> refreshAccessToken(String refreshToken, String clientId, String clientSecret);
+
+    /**
+     * Overrides close() in AutoCloseable as no meaningful exception can be handled.
+     */
+    @Override
+    void close();
 }

--- a/src/main/java/com/laserfiche/api/client/oauth/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/TokenClient.java
@@ -38,7 +38,8 @@ public interface TokenClient extends AutoCloseable {
     CompletableFuture<GetAccessTokenResponse> refreshAccessToken(String refreshToken, String clientId, String clientSecret);
 
     /**
-     * Overrides close() in AutoCloseable as no meaningful exception can be handled.
+     * Since the underlying resource (the HTTP client) won't throw any exception during its close() invocation.
+     * We override the signature of the close() to not include any checked exception.
      */
     @Override
     void close();

--- a/src/main/java/com/laserfiche/api/client/oauth/TokenClientImpl.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/TokenClientImpl.java
@@ -5,7 +5,6 @@ import com.laserfiche.api.client.model.AccessKey;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.GetAccessTokenResponse;
 import com.laserfiche.api.client.model.ProblemDetails;
-import kong.unirest.Unirest;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -16,7 +15,7 @@ import static com.laserfiche.api.client.oauth.OAuthUtil.getOAuthApiBaseUri;
 
 
 public class TokenClientImpl extends OAuthClient implements TokenClient {
-    private String baseUrl;
+    private final String baseUrl;
 
     public TokenClientImpl(String regionalDomain) {
         super();
@@ -27,7 +26,7 @@ public class TokenClientImpl extends OAuthClient implements TokenClient {
     public CompletableFuture<GetAccessTokenResponse> getAccessTokenFromServicePrincipal(String spKey,
             AccessKey accessKey) {
         String bearer = createBearer(spKey, accessKey);
-        return Unirest
+        return httpClient
                 .post(baseUrl + "Token")
                 .header("Authorization", bearer)
                 .header("Content-Type", "application/x-www-form-urlencoded")
@@ -84,5 +83,4 @@ public class TokenClientImpl extends OAuthClient implements TokenClient {
             String clientSecret) {
         return null;
     }
-
 }

--- a/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
@@ -3,6 +3,8 @@ package com.laserfiche.api.client.integration;
 import com.laserfiche.api.client.httphandlers.*;
 import com.laserfiche.api.client.model.ApiException;
 import kong.unirest.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,9 +21,18 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 public class UsernamePasswordHandlerTest extends BaseTest {
     private HttpRequestHandler httpRequestHandler;
 
+    @BeforeEach
+    void setUpHttpRequestHandler() {
+        httpRequestHandler = new UsernamePasswordHandler(repoId, username, password, baseUrl, null);
+    }
+
+    @AfterEach
+    void tearDownHttpRequestHandler() {
+        httpRequestHandler.close();
+    }
+
     @Test
     void beforeSendAsync_NewToken_Success() {
-        httpRequestHandler = new UsernamePasswordHandler(repoId, username, password, baseUrl, null);
         Request request = new RequestImpl();
 
         // Act
@@ -47,7 +58,6 @@ public class UsernamePasswordHandlerTest extends BaseTest {
     @Test
     void beforeSendAsync_ExistingToken_Success() {
         // Arrange
-        httpRequestHandler = new UsernamePasswordHandler(repoId, username, password, baseUrl, null);
         Request request1 = new RequestImpl();
         Request request2 = new RequestImpl();
 
@@ -88,7 +98,6 @@ public class UsernamePasswordHandlerTest extends BaseTest {
     @Test
     void afterSendAsync_TokenRemovedWhenUnauthorized() {
         // Arrange
-        httpRequestHandler = new UsernamePasswordHandler(repoId, username, password, baseUrl, null);
         Request request1 = new RequestImpl();
         BeforeSendResult result1 = httpRequestHandler
                 .beforeSendAsync(request1)
@@ -134,7 +143,6 @@ public class UsernamePasswordHandlerTest extends BaseTest {
     @MethodSource("failedAuthentication")
     void beforeSendAsync_FailedAuthentication_ThrowsException(String repoId, String username, String password,
             int status) {
-        httpRequestHandler = new UsernamePasswordHandler(repoId, username, password, baseUrl, null);
         Request request = new RequestImpl();
         assertThrows(RuntimeException.class, () -> CompletableFuture.completedFuture(httpRequestHandler
                 .beforeSendAsync(request)

--- a/src/test/java/com/laserfiche/api/client/unit/OAuthClientCredentialsHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/OAuthClientCredentialsHandlerTest.java
@@ -14,15 +14,16 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
     @Test
     void afterSendAsync_ShouldNotRetry() {
         // Arrange
-        HttpRequestHandler handler = new OAuthClientCredentialsHandler(spKey, accessKey);
-        Response mockedResponse = mock(Response.class);
-        when(mockedResponse.status()).thenReturn((short)200);
+        try (HttpRequestHandler handler = new OAuthClientCredentialsHandler(spKey, accessKey)) {
+            Response mockedResponse = mock(Response.class);
+            when(mockedResponse.status()).thenReturn((short)200);
 
-        // Act
-        handler.afterSendAsync(mockedResponse).thenApply((shouldRetry) -> {
-            // Assert
-            assertEquals(false, shouldRetry);
-            return null;
-        });
+            // Act
+            handler.afterSendAsync(mockedResponse).thenApply((shouldRetry) -> {
+                // Assert
+                assertEquals(false, shouldRetry);
+                return null;
+            });
+        }
     }
 }

--- a/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
@@ -6,6 +6,8 @@ import com.laserfiche.api.client.apiserver.TokenClientImpl;
 import com.laserfiche.api.client.httphandlers.*;
 import com.laserfiche.api.client.model.CreateConnectionRequest;
 import kong.unirest.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,11 +24,23 @@ import static org.mockito.Mockito.*;
 
 public class UsernamePasswordHandlerTest {
 
-    private String repoId = "repoId";
-    private String username = "username";
-    private String password = "password";
-    private String baseUrl = "http://localhost:11211";
-    private Request _request = new RequestImpl();
+    private final String repoId = "repoId";
+    private final String username = "username";
+    private final String password = "password";
+    private final String baseUrl = "http://localhost:11211";
+    private final Request _request = new RequestImpl();
+
+    private HttpRequestHandler handler;
+
+    @BeforeEach
+    void setUpHttpRequestHandler() {
+        handler = new UsernamePasswordHandler(repoId, username, password, baseUrl, null);
+    }
+
+    @AfterEach
+    void tearDownHttpRequestHandler() {
+        handler.close();
+    }
 
     @Test
     @Disabled("Throwing a null exception -> will have to figure out how to stub completable future type functions")
@@ -41,12 +55,12 @@ public class UsernamePasswordHandlerTest {
                 CompletableFuture.completedFuture(mockedResponse));
         HttpRequestHandler handler = new UsernamePasswordHandler(repoId, username, password, baseUrl, mockedClient);
 
-        //Act
+        // Act
         BeforeSendResult result = handler
                 .beforeSendAsync(_request)
                 .join();
 
-        //Assert
+        // Assert
         assertNotNull(result);
         assertNull(result.getRegionalDomain());
         assertTrue(_request
@@ -66,7 +80,6 @@ public class UsernamePasswordHandlerTest {
     @Test
     void afterSendAsync_ResponseUnauthorized_ReturnsTrue() {
         // Arrange
-        HttpRequestHandler handler = new UsernamePasswordHandler(repoId, username, password, baseUrl, null);
         Response mockedResponse = mock(Response.class);
         when(mockedResponse.status()).thenReturn((short) 401);
 
@@ -84,7 +97,6 @@ public class UsernamePasswordHandlerTest {
     @MethodSource("responseOtherThanUnauthorized")
     void afterSendAsync_ResponseOtherThanUnauthorized_ReturnsFalse(int status) {
         // Arrange
-        HttpRequestHandler handler = new UsernamePasswordHandler(repoId, username, password, baseUrl, null);
         Response mockedResponse = mock(Response.class);
         when(mockedResponse.status()).thenReturn((short) status);
 


### PR DESCRIPTION
Because the HTTP client holds resources (thread pool) and needs explicit [shutdown](http://kong.github.io/unirest-java/), we add an API so that the user could either automatically dispose the resource (use the [try-with-resource pattern](https://www.baeldung.com/java-try-with-resources), similar to "using" in C#). The object relationship is rather complicated so please refer to the diagrams below in addition to code.

Before this PR, the object relationship looks like this:
![client-core-java-class-diagram-before-autocloseable](https://user-images.githubusercontent.com/101835056/201951333-b22a0766-9f62-49f0-8d79-59bd569e1bba.svg)

After this PR, it becomes:
![client-core-java-class-diagram-after-autocloseable](https://user-images.githubusercontent.com/101835056/201951380-9bc76f9e-e75e-4474-9717-4e7b6c82bbc2.svg)

Note: "_C" and "_S" marks "cloud" and "self-hosted". The mark is not part of the class name, but rather a mark for the diagram.