### PR TITLE
Convert Async API to Blocking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>lf-api-client-core</artifactId>
   <packaging>jar</packaging>
   <name>Laserfiche API Client Core</name>
-  <version>1.1.0</version>
+  <version>2.0.0</version>
   <url>https://github.com/Laserfiche/lf-api-client-core-java</url>
   <description>Java implementation of various foundational APIs for Laserfiche, including authorization APIs such as
     OAuth 2.0 flows for secure and easy access to Laserfiche APIs.

--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
@@ -3,8 +3,6 @@ package com.laserfiche.api.client.apiserver;
 import com.laserfiche.api.client.model.CreateConnectionRequest;
 import com.laserfiche.api.client.model.SessionKeyInfo;
 
-import java.util.concurrent.CompletableFuture;
-
 public interface TokenClient extends AutoCloseable {
 
     /**
@@ -12,7 +10,7 @@ public interface TokenClient extends AutoCloseable {
      * @param body   Request body that contains username, password and grant type
      * @return Create an access token successfully.
      */
-    CompletableFuture<SessionKeyInfo> createAccessToken(String repoId, CreateConnectionRequest body);
+    SessionKeyInfo createAccessToken(String repoId, CreateConnectionRequest body);
 
     /**
      * Since the underlying resource (the HTTP client) won't throw any exception during its close() invocation.

--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
@@ -8,7 +8,7 @@ public interface TokenClient extends AutoCloseable {
     /**
      * @param repoId Repository name
      * @param body   Request body that contains username, password and grant type
-     * @return Create an access token successfully.
+     * @return A SessionKeyInfo object that contains an access token.
      */
     SessionKeyInfo createAccessToken(String repoId, CreateConnectionRequest body);
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
@@ -7,14 +7,14 @@ public interface HttpRequestHandler extends AutoCloseable {
      * @param request The request that will have the authorization header set.
      * @return The request that has the authorization header already set.
      */
-    BeforeSendResult beforeSendAsync(Request request);
+    BeforeSendResult beforeSend(Request request);
 
     /**
      * Invoked after an HTTP request with the response message and cancellation token.
      * @param response The HTTP response.
      * @return True if the request should be retried.
      */
-    boolean afterSendAsync(Response response);
+    boolean afterSend(Response response);
 
     /**
      * Since the underlying resource (the HTTP client) won't throw any exception during its close() invocation.

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
@@ -1,7 +1,5 @@
 package com.laserfiche.api.client.httphandlers;
 
-import java.util.concurrent.CompletableFuture;
-
 public interface HttpRequestHandler extends AutoCloseable {
 
     /**
@@ -9,14 +7,14 @@ public interface HttpRequestHandler extends AutoCloseable {
      * @param request The request that will have the authorization header set.
      * @return The request that has the authorization header already set.
      */
-    CompletableFuture<BeforeSendResult> beforeSendAsync(Request request);
+    BeforeSendResult beforeSendAsync(Request request);
 
     /**
      * Invoked after an HTTP request with the response message and cancellation token.
      * @param response The HTTP response.
      * @return True if the request should be retried.
      */
-    CompletableFuture<Boolean> afterSendAsync(Response response);
+    boolean afterSendAsync(Response response);
 
     /**
      * Since the underlying resource (the HTTP client) won't throw any exception during its close() invocation.

--- a/src/main/java/com/laserfiche/api/client/httphandlers/OAuthClientCredentialsHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/OAuthClientCredentialsHandler.java
@@ -5,8 +5,6 @@ import com.laserfiche.api.client.model.GetAccessTokenResponse;
 import com.laserfiche.api.client.oauth.TokenClient;
 import com.laserfiche.api.client.oauth.TokenClientImpl;
 
-import java.util.concurrent.CompletableFuture;
-
 public class OAuthClientCredentialsHandler implements HttpRequestHandler {
     private String accessToken;
     private final String spKey;
@@ -20,8 +18,7 @@ public class OAuthClientCredentialsHandler implements HttpRequestHandler {
     }
 
     @Override
-    public BeforeSendResult beforeSendAsync(com.laserfiche.api.client.httphandlers.Request request) {
-        CompletableFuture<GetAccessTokenResponse> future;
+    public BeforeSendResult beforeSend(com.laserfiche.api.client.httphandlers.Request request) {
         BeforeSendResult result = new BeforeSendResult();
         if (accessToken == null || accessToken.equals("")) {
             GetAccessTokenResponse tokenResponse  = client.getAccessTokenFromServicePrincipal(spKey, accessKey);
@@ -33,7 +30,7 @@ public class OAuthClientCredentialsHandler implements HttpRequestHandler {
     }
 
     @Override
-    public boolean afterSendAsync(com.laserfiche.api.client.httphandlers.Response response) {
+    public boolean afterSend(com.laserfiche.api.client.httphandlers.Response response) {
         boolean shouldRetry = (response.status() == 401);
         if (shouldRetry) {
             accessToken = null; // In case exception happens when getting the access token

--- a/src/main/java/com/laserfiche/api/client/httphandlers/UsernamePasswordHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/UsernamePasswordHandler.java
@@ -38,7 +38,7 @@ public class UsernamePasswordHandler implements HttpRequestHandler {
     }
 
     @Override
-    public BeforeSendResult beforeSendAsync(Request request) {
+    public BeforeSendResult beforeSend(Request request) {
         BeforeSendResult result = new BeforeSendResult();
         if (accessToken == null) {
             SessionKeyInfo tokenResponse = client.createAccessToken(repositoryId, this.request);
@@ -56,7 +56,7 @@ public class UsernamePasswordHandler implements HttpRequestHandler {
     }
 
     @Override
-    public boolean afterSendAsync(Response response) {
+    public boolean afterSend(Response response) {
         boolean shouldRetry = (response.status() == 401);
         if (shouldRetry) {
             accessToken = null; // In case exception happens when getting the access token

--- a/src/main/java/com/laserfiche/api/client/oauth/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/TokenClient.java
@@ -3,8 +3,6 @@ package com.laserfiche.api.client.oauth;
 import com.laserfiche.api.client.model.AccessKey;
 import com.laserfiche.api.client.model.GetAccessTokenResponse;
 
-import java.util.concurrent.CompletableFuture;
-
 public interface TokenClient extends AutoCloseable {
     /**
      * Gets an OAuth access token given a Laserfiche cloud service principal key and an OAuth service application access key.
@@ -13,7 +11,7 @@ public interface TokenClient extends AutoCloseable {
      * @param accessKey OAuth service application access key
      * @return A response that contains an access token
      */
-    CompletableFuture<GetAccessTokenResponse> getAccessTokenFromServicePrincipal(String spKey, AccessKey accessKey);
+    GetAccessTokenResponse getAccessTokenFromServicePrincipal(String spKey, AccessKey accessKey);
 
     /**
      * Gets an OAuth access token given an OAuth code.
@@ -25,7 +23,7 @@ public interface TokenClient extends AutoCloseable {
      * @param codeVerifier OPTIONAL PKCE code verifier. Required for SPA apps.
      * @return A response that contains an access token
      */
-    CompletableFuture<GetAccessTokenResponse> getAccessTokenFromCode(String code, String redirectUri, String clientId, String clientSecret, String codeVerifier);
+    GetAccessTokenResponse getAccessTokenFromCode(String code, String redirectUri, String clientId, String clientSecret, String codeVerifier);
 
     /**
      * Gets a refreshed access token given a refresh token.
@@ -35,7 +33,7 @@ public interface TokenClient extends AutoCloseable {
      * @param clientSecret OPTIONAL OAuth application client secret. Required for web apps.
      * @return A response that contains an access token
      */
-    CompletableFuture<GetAccessTokenResponse> refreshAccessToken(String refreshToken, String clientId, String clientSecret);
+    GetAccessTokenResponse refreshAccessToken(String refreshToken, String clientId, String clientSecret);
 
     /**
      * Since the underlying resource (the HTTP client) won't throw any exception during its close() invocation.

--- a/src/main/java/com/laserfiche/api/client/oauth/TokenClientImpl.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/TokenClientImpl.java
@@ -5,10 +5,10 @@ import com.laserfiche.api.client.model.AccessKey;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.GetAccessTokenResponse;
 import com.laserfiche.api.client.model.ProblemDetails;
+import kong.unirest.HttpResponse;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 import static com.laserfiche.api.client.oauth.OAuthUtil.createBearer;
 import static com.laserfiche.api.client.oauth.OAuthUtil.getOAuthApiBaseUri;
@@ -23,64 +23,62 @@ public class TokenClientImpl extends OAuthClient implements TokenClient {
     }
 
     @Override
-    public CompletableFuture<GetAccessTokenResponse> getAccessTokenFromServicePrincipal(String spKey,
+    public GetAccessTokenResponse getAccessTokenFromServicePrincipal(String spKey,
             AccessKey accessKey) {
         String bearer = createBearer(spKey, accessKey);
-        return httpClient
+        HttpResponse<Object> httpResponse = httpClient
                 .post(baseUrl + "Token")
                 .header("Authorization", bearer)
                 .header("Content-Type", "application/x-www-form-urlencoded")
                 .field("grant_type", "client_credentials")
-                .asObjectAsync(Object.class)
-                .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 200) {
-                        try {
-                            String jsonString = new JSONObject(httpResponse.getBody()).toString();
-                            return objectMapper.readValue(jsonString, GetAccessTokenResponse.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
-                        }
-                    } else {
-                        ProblemDetails problemDetails;
-                        try {
-                            String jsonString = new JSONObject(httpResponse.getBody()).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
-                        }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
-                        if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else
-                            throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                });
+                .asObject(Object.class);
+
+        if (httpResponse.getStatus() == 200) {
+            try {
+                String jsonString = new JSONObject(httpResponse.getBody()).toString();
+                return objectMapper.readValue(jsonString, GetAccessTokenResponse.class);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                return null;
+            }
+        } else {
+            ProblemDetails problemDetails;
+            try {
+                String jsonString = new JSONObject(httpResponse.getBody()).toString();
+                problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                return null;
+            }
+            Map<String, String> headersMap = getHeadersMap(httpResponse);
+            if (httpResponse.getStatus() == 400)
+                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
+            else if (httpResponse.getStatus() == 401)
+                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
+            else if (httpResponse.getStatus() == 403)
+                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
+            else if (httpResponse.getStatus() == 404)
+                throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                        headersMap, problemDetails);
+            else if (httpResponse.getStatus() == 429)
+                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
+            else
+                throw new RuntimeException(httpResponse.getStatusText());
+        }
     }
 
     @Override
-    public CompletableFuture<GetAccessTokenResponse> getAccessTokenFromCode(String code, String redirectUri,
-            String clientId, String clientSecret, String codeVerifier) {
+    public GetAccessTokenResponse getAccessTokenFromCode(String code, String redirectUri, String clientId,
+            String clientSecret, String codeVerifier) {
         return null;
     }
 
     @Override
-    public CompletableFuture<GetAccessTokenResponse> refreshAccessToken(String refreshToken, String clientId,
-            String clientSecret) {
+    public GetAccessTokenResponse refreshAccessToken(String refreshToken, String clientId, String clientSecret) {
         return null;
     }
 }

--- a/src/test/java/com/laserfiche/api/client/integration/OAuthClientCredentialsHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/OAuthClientCredentialsHandlerTest.java
@@ -164,7 +164,7 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
             Request request = new RequestImpl();
             assertThrows(RuntimeException.class, () -> handler.beforeSend(request));
             RuntimeException ex = assertThrows(RuntimeException.class, () -> handler.beforeSend(request));
-            ApiException exception = (ApiException) ex.getCause();
+            ApiException exception = (ApiException) ex;
             assertEquals(401, exception.getStatusCode());
             assertNotNull(exception
                     .getProblemDetails()

--- a/src/test/java/com/laserfiche/api/client/integration/OAuthClientCredentialsHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/OAuthClientCredentialsHandlerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -38,8 +37,7 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
         Request request = new RequestImpl();
 
         // Request access token
-        CompletableFuture<BeforeSendResult> future = handler.beforeSendAsync(request);
-        BeforeSendResult result = future.join();
+        BeforeSendResult result = handler.beforeSend(request);
 
         assertNotEquals(null, result.getRegionalDomain());
         assertNotEquals(null, request
@@ -55,8 +53,7 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
         Request request1 = new RequestImpl();
 
         // First time to request access token
-        CompletableFuture<BeforeSendResult> future1 = handler.beforeSendAsync(request1);
-        BeforeSendResult result1 = future1.join();
+        BeforeSendResult result1 = handler.beforeSend(request1);
 
         // First request should work
         assertNotEquals(null, result1.getRegionalDomain());
@@ -69,8 +66,7 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
 
         // Subsequent request should also work
         Request request2 = new RequestImpl();
-        CompletableFuture<BeforeSendResult> future2 = handler.beforeSendAsync(request2);
-        BeforeSendResult result2 = future2.join();
+        BeforeSendResult result2 = handler.beforeSend(request2);
 
         assertNotEquals(null, result2.getRegionalDomain());
         assertNotEquals(null, request2
@@ -92,13 +88,10 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
         when(mockedResponse.status()).thenReturn((short) 401);
 
         // Request access token then simulate a 401
-        CompletableFuture<BeforeSendResult> tokenFuture = handler.beforeSendAsync(new RequestImpl());
-        tokenFuture
-                .thenCompose(beforeSendResult -> handler.afterSendAsync(mockedResponse))
-                .thenApply((shouldRetry) -> {
-                    assertEquals(true, shouldRetry);
-                    return null;
-                });
+        handler.beforeSend(new RequestImpl());
+        boolean shouldRetry = handler.afterSend(mockedResponse);
+
+        assertTrue(shouldRetry);
     }
 
     @ParameterizedTest
@@ -106,13 +99,11 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
     void afterSendAsync_DoNotRetry(int status) {
         Response mockedResponse = mock(Response.class);
         when(mockedResponse.status()).thenReturn((short) status);
-        CompletableFuture<BeforeSendResult> tokenFuture = handler.beforeSendAsync(new RequestImpl());
-        tokenFuture
-                .thenCompose(beforeSendResult -> handler.afterSendAsync(mockedResponse))
-                .thenApply((shouldRetry) -> {
-                    assertFalse(shouldRetry);
-                    return null;
-                });
+
+        handler.beforeSend(new RequestImpl());
+        boolean shouldRetry = handler.afterSend(mockedResponse);
+
+        assertFalse(shouldRetry);
     }
 
     private static Stream<Arguments> falseAuthentication() {
@@ -125,9 +116,9 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
     @Test
     void afterSendAsync_DoRetry_AccessTokenRemoved() {
         Request request1 = new RequestImpl();
+
         // Request access token
-        CompletableFuture<BeforeSendResult> future = handler.beforeSendAsync(request1);
-        BeforeSendResult result = future.join();
+        BeforeSendResult result = handler.beforeSend(request1);
         String bearerTokenParameter1 = request1
                 .headers()
                 .get("Authorization")
@@ -142,20 +133,15 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
         assertNotNull(bearerTokenParameter1);
         assertEquals(accessKey.getDomain(), result.getRegionalDomain());
 
-        //Remove the access token
+        // Remove the access token
         Response mockedResponse = mock(Response.class);
         when(mockedResponse.status()).thenReturn((short) 401);
-        future
-                .thenCompose(beforeSendResult -> handler.afterSendAsync(mockedResponse))
-                .thenApply((shouldRetry) -> {
-                    assertEquals(true, shouldRetry);
-                    return null;
-                });
+        boolean shouldRetry = handler.afterSend(mockedResponse);
+        assertTrue(shouldRetry);
 
         //Get a new access token
         Request request2 = new RequestImpl();
-        CompletableFuture<BeforeSendResult> future2 = handler.beforeSendAsync(request2);
-        BeforeSendResult result2 = future2.join();
+        BeforeSendResult result2 = handler.beforeSend(request2);
         String bearerTokenParameter2 = request2
                 .headers()
                 .get("Authorization")
@@ -176,12 +162,8 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
     void beforeSendAsync_FailedAuthentication_ThrowsException() {
         try (HttpRequestHandler handler = new OAuthClientCredentialsHandler("fake1243", accessKey)) {
             Request request = new RequestImpl();
-            assertThrows(RuntimeException.class, () -> CompletableFuture.completedFuture(handler
-                    .beforeSendAsync(request)
-                    .join()));
-            RuntimeException ex = assertThrows(RuntimeException.class, () -> handler
-                    .beforeSendAsync(request)
-                    .join());
+            assertThrows(RuntimeException.class, () -> handler.beforeSend(request));
+            RuntimeException ex = assertThrows(RuntimeException.class, () -> handler.beforeSend(request));
             ApiException exception = (ApiException) ex.getCause();
             assertEquals(401, exception.getStatusCode());
             assertNotNull(exception

--- a/src/test/java/com/laserfiche/api/client/integration/TokenClientImplTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/TokenClientImplTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -51,7 +50,7 @@ class TokenClientImplTest extends BaseTest {
                 .replace("laserfiche", "lf");
 
         try (TokenClient client = new TokenClientImpl(incorrectDomain)) {
-            Exception exception = assertThrows(ExecutionException.class,
+            Exception exception = assertThrows(RuntimeException.class,
                     () -> client.getAccessTokenFromServicePrincipal(spKey, accessKey));
             assertTrue(IOException.class.isAssignableFrom(exception
                     .getCause()

--- a/src/test/java/com/laserfiche/api/client/integration/TokenClientImplTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/TokenClientImplTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -30,8 +29,7 @@ class TokenClientImplTest extends BaseTest {
 
     @Test
     void getAccessTokenFromServicePrincipal_Success() {
-        CompletableFuture<GetAccessTokenResponse> future = client.getAccessTokenFromServicePrincipal(spKey, accessKey);
-        GetAccessTokenResponse response = future.join();
+        GetAccessTokenResponse response = client.getAccessTokenFromServicePrincipal(spKey, accessKey);
 
         assertNotEquals(null, response);
         assertNotEquals(null, response.getAccessToken());
@@ -40,21 +38,24 @@ class TokenClientImplTest extends BaseTest {
     @Test
     void getAccessTokenFromServicePrincipal_InvalidAccessKey() {
         accessKey.setClientId("wrong client ID");
-        CompletableFuture<GetAccessTokenResponse> future = client.getAccessTokenFromServicePrincipal(spKey, accessKey);
 
-        Exception exception = assertThrows(RuntimeException.class, future::join);
+        Exception exception = assertThrows(RuntimeException.class,
+                () -> client.getAccessTokenFromServicePrincipal(spKey, accessKey));
         assertNotNull(exception);
     }
 
     @Test
     void getAccessTokenFromServicePrincipal_IoError() {
-        String incorrectDomain = accessKey.getDomain().replace("laserfiche", "lf");
+        String incorrectDomain = accessKey
+                .getDomain()
+                .replace("laserfiche", "lf");
 
         try (TokenClient client = new TokenClientImpl(incorrectDomain)) {
-            CompletableFuture<GetAccessTokenResponse> future = client.getAccessTokenFromServicePrincipal(spKey, accessKey);
-
-            Exception exception = assertThrows(ExecutionException.class, future::get);
-            assertTrue(IOException.class.isAssignableFrom(exception.getCause().getClass()));
+            Exception exception = assertThrows(ExecutionException.class,
+                    () -> client.getAccessTokenFromServicePrincipal(spKey, accessKey));
+            assertTrue(IOException.class.isAssignableFrom(exception
+                    .getCause()
+                    .getClass()));
         }
     }
 }

--- a/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
@@ -36,7 +36,7 @@ public class UsernamePasswordHandlerTest extends BaseTest {
         Request request = new RequestImpl();
 
         // Act
-        CompletableFuture<BeforeSendResult> future = httpRequestHandler.beforeSendAsync(request);
+        CompletableFuture<BeforeSendResult> future = httpRequestHandler.beforeSend(request);
         BeforeSendResult result = future.join();
 
         // Assert
@@ -63,11 +63,11 @@ public class UsernamePasswordHandlerTest extends BaseTest {
 
         // Act
         BeforeSendResult result1 = httpRequestHandler
-                .beforeSendAsync(request1)
+                .beforeSend(request1)
                 .join();
 
         BeforeSendResult result2 = httpRequestHandler
-                .beforeSendAsync(request2)
+                .beforeSend(request2)
                 .join();
 
         String bearerTokenParameter1 = request1
@@ -100,19 +100,19 @@ public class UsernamePasswordHandlerTest extends BaseTest {
         // Arrange
         Request request1 = new RequestImpl();
         BeforeSendResult result1 = httpRequestHandler
-                .beforeSendAsync(request1)
+                .beforeSend(request1)
                 .join();
 
         // Act
         Boolean retry = httpRequestHandler
-                .afterSendAsync(new ResponseImpl((short) HttpStatus.UNAUTHORIZED))
+                .afterSend(new ResponseImpl((short) HttpStatus.UNAUTHORIZED))
                 .join();
 
         // Assert
         assertTrue(retry);
         Request request2 = new RequestImpl();
         BeforeSendResult result2 = httpRequestHandler
-                .beforeSendAsync(request2)
+                .beforeSend(request2)
                 .join();
 
         String bearerTokenParameter1 = request1
@@ -145,10 +145,10 @@ public class UsernamePasswordHandlerTest extends BaseTest {
             int status) {
         Request request = new RequestImpl();
         assertThrows(RuntimeException.class, () -> CompletableFuture.completedFuture(httpRequestHandler
-                .beforeSendAsync(request)
+                .beforeSend(request)
                 .join()));
         RuntimeException ex = assertThrows(RuntimeException.class, () -> httpRequestHandler
-                .beforeSendAsync(request)
+                .beforeSend(request)
                 .join());
         ApiException exception = (ApiException) ex.getCause();
         assertEquals(status, exception.getStatusCode());

--- a/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
@@ -132,20 +132,23 @@ public class UsernamePasswordHandlerTest extends BaseTest {
 
     @ParameterizedTest
     @MethodSource("failedAuthentication")
-    void beforeSendAsync_FailedAuthentication_ThrowsException(int status) {
-        Request request = new RequestImpl();
-        assertThrows(RuntimeException.class, () -> httpRequestHandler.beforeSend(request));
+    void beforeSendAsync_FailedAuthentication_ThrowsException(String repoId, String username, String password,
+            int status) {
+        try (HttpRequestHandler badHandler = new UsernamePasswordHandler(repoId, username, password, baseUrl, null)) {
+            Request request = new RequestImpl();
+            assertThrows(RuntimeException.class, () -> badHandler.beforeSend(request));
 
-        RuntimeException ex = assertThrows(RuntimeException.class, () -> httpRequestHandler.beforeSend(request));
+            RuntimeException ex = assertThrows(RuntimeException.class, () -> badHandler.beforeSend(request));
 
-        ApiException exception = (ApiException) ex.getCause();
-        assertEquals(status, exception.getStatusCode());
-        assertNotNull(exception
-                .getProblemDetails()
-                .get("type"));
-        assertNotNull(exception
-                .getProblemDetails()
-                .get("title"));
+            ApiException exception = (ApiException) ex;
+            assertEquals(status, exception.getStatusCode());
+            assertNotNull(exception
+                    .getProblemDetails()
+                    .get("type"));
+            assertNotNull(exception
+                    .getProblemDetails()
+                    .get("title"));
+        }
     }
 
     private static Stream<Arguments> failedAuthentication() {

--- a/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,8 +35,7 @@ public class UsernamePasswordHandlerTest extends BaseTest {
         Request request = new RequestImpl();
 
         // Act
-        CompletableFuture<BeforeSendResult> future = httpRequestHandler.beforeSend(request);
-        BeforeSendResult result = future.join();
+        BeforeSendResult result = httpRequestHandler.beforeSend(request);
 
         // Assert
         assertNotNull(result);
@@ -62,13 +60,8 @@ public class UsernamePasswordHandlerTest extends BaseTest {
         Request request2 = new RequestImpl();
 
         // Act
-        BeforeSendResult result1 = httpRequestHandler
-                .beforeSend(request1)
-                .join();
-
-        BeforeSendResult result2 = httpRequestHandler
-                .beforeSend(request2)
-                .join();
+        httpRequestHandler.beforeSend(request1);
+        BeforeSendResult result = httpRequestHandler.beforeSend(request2);
 
         String bearerTokenParameter1 = request1
                 .headers()
@@ -77,6 +70,7 @@ public class UsernamePasswordHandlerTest extends BaseTest {
                         .headers()
                         .get("Authorization")
                         .length() - 1);
+
         String bearerTokenParameter2 = request2
                 .headers()
                 .get("Authorization")
@@ -84,9 +78,10 @@ public class UsernamePasswordHandlerTest extends BaseTest {
                         .headers()
                         .get("Authorization")
                         .length() - 1);
+
         // Assert
-        assertNotNull(result2);
-        assertNull(result2.getRegionalDomain());
+        assertNotNull(result);
+        assertNull(result.getRegionalDomain());
         assertTrue(request2
                 .headers()
                 .get("Authorization")
@@ -99,21 +94,15 @@ public class UsernamePasswordHandlerTest extends BaseTest {
     void afterSendAsync_TokenRemovedWhenUnauthorized() {
         // Arrange
         Request request1 = new RequestImpl();
-        BeforeSendResult result1 = httpRequestHandler
-                .beforeSend(request1)
-                .join();
+        Request request2 = new RequestImpl();
+        httpRequestHandler.beforeSend(request1);
 
         // Act
-        Boolean retry = httpRequestHandler
-                .afterSend(new ResponseImpl((short) HttpStatus.UNAUTHORIZED))
-                .join();
+        boolean shouldRetry = httpRequestHandler.afterSend(new ResponseImpl((short) HttpStatus.UNAUTHORIZED));
 
         // Assert
-        assertTrue(retry);
-        Request request2 = new RequestImpl();
-        BeforeSendResult result2 = httpRequestHandler
-                .beforeSend(request2)
-                .join();
+        assertTrue(shouldRetry);
+        BeforeSendResult result2 = httpRequestHandler.beforeSend(request2);
 
         String bearerTokenParameter1 = request1
                 .headers()
@@ -122,6 +111,7 @@ public class UsernamePasswordHandlerTest extends BaseTest {
                         .headers()
                         .get("Authorization")
                         .length() - 1);
+
         String bearerTokenParameter2 = request2
                 .headers()
                 .get("Authorization")
@@ -129,6 +119,7 @@ public class UsernamePasswordHandlerTest extends BaseTest {
                         .headers()
                         .get("Authorization")
                         .length() - 1);
+
         assertNotNull(result2);
         assertNull(result2.getRegionalDomain());
         assertTrue(request2
@@ -141,15 +132,12 @@ public class UsernamePasswordHandlerTest extends BaseTest {
 
     @ParameterizedTest
     @MethodSource("failedAuthentication")
-    void beforeSendAsync_FailedAuthentication_ThrowsException(String repoId, String username, String password,
-            int status) {
+    void beforeSendAsync_FailedAuthentication_ThrowsException(int status) {
         Request request = new RequestImpl();
-        assertThrows(RuntimeException.class, () -> CompletableFuture.completedFuture(httpRequestHandler
-                .beforeSend(request)
-                .join()));
-        RuntimeException ex = assertThrows(RuntimeException.class, () -> httpRequestHandler
-                .beforeSend(request)
-                .join());
+        assertThrows(RuntimeException.class, () -> httpRequestHandler.beforeSend(request));
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> httpRequestHandler.beforeSend(request));
+
         ApiException exception = (ApiException) ex.getCause();
         assertEquals(status, exception.getStatusCode());
         assertNotNull(exception

--- a/src/test/java/com/laserfiche/api/client/unit/OAuthClientCredentialsHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/OAuthClientCredentialsHandlerTest.java
@@ -19,7 +19,7 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
             when(mockedResponse.status()).thenReturn((short)200);
 
             // Act
-            handler.afterSendAsync(mockedResponse).thenApply((shouldRetry) -> {
+            handler.afterSend(mockedResponse).thenApply((shouldRetry) -> {
                 // Assert
                 assertEquals(false, shouldRetry);
                 return null;

--- a/src/test/java/com/laserfiche/api/client/unit/OAuthClientCredentialsHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/OAuthClientCredentialsHandlerTest.java
@@ -6,7 +6,7 @@ import com.laserfiche.api.client.httphandlers.Response;
 import com.laserfiche.api.client.integration.BaseTest;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,11 +19,10 @@ class OAuthClientCredentialsHandlerTest extends BaseTest {
             when(mockedResponse.status()).thenReturn((short)200);
 
             // Act
-            handler.afterSend(mockedResponse).thenApply((shouldRetry) -> {
-                // Assert
-                assertEquals(false, shouldRetry);
-                return null;
-            });
+            boolean shouldRetry = handler.afterSend(mockedResponse);
+
+            // Assert
+            assertFalse(shouldRetry);
         }
     }
 }

--- a/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
@@ -1,10 +1,10 @@
 package com.laserfiche.api.client.unit;
 
-import com.laserfiche.api.client.model.SessionKeyInfo;
 import com.laserfiche.api.client.apiserver.TokenClient;
 import com.laserfiche.api.client.apiserver.TokenClientImpl;
 import com.laserfiche.api.client.httphandlers.*;
 import com.laserfiche.api.client.model.CreateConnectionRequest;
+import com.laserfiche.api.client.model.SessionKeyInfo;
 import kong.unirest.HttpStatus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,7 +14,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -50,14 +49,11 @@ public class UsernamePasswordHandlerTest {
         mockedResponse.setAccessToken(accessToken);
         CreateConnectionRequest mockedBody = mock(CreateConnectionRequest.class);
         TokenClient mockedClient = mock(TokenClientImpl.class);
-        when(mockedClient.createAccessToken(eq(anyString()), mockedBody)).thenReturn(
-                CompletableFuture.completedFuture(mockedResponse));
+        when(mockedClient.createAccessToken(eq(anyString()), mockedBody)).thenReturn(mockedResponse);
         HttpRequestHandler handler = new UsernamePasswordHandler(repoId, username, password, baseUrl, mockedClient);
 
         // Act
-        BeforeSendResult result = handler
-                .beforeSend(request)
-                .join();
+        BeforeSendResult result = handler.beforeSend(request);
 
         // Assert
         assertNotNull(result);
@@ -83,13 +79,10 @@ public class UsernamePasswordHandlerTest {
         when(mockedResponse.status()).thenReturn((short) 401);
 
         // Act
-        handler
-                .afterSend(mockedResponse)
-                .thenApply((shouldRetry) -> {
-                    // Assert
-                    assertEquals(true, shouldRetry);
-                    return null;
-                });
+        boolean shouldRetry = handler.afterSend(mockedResponse);
+
+        // Assert
+        assertTrue(shouldRetry);
     }
 
     @ParameterizedTest
@@ -100,13 +93,10 @@ public class UsernamePasswordHandlerTest {
         when(mockedResponse.status()).thenReturn((short) status);
 
         // Act
-        handler
-                .afterSend(mockedResponse)
-                .thenApply((shouldRetry) -> {
-                    // Assert
-                    assertEquals(false, shouldRetry);
-                    return null;
-                });
+        boolean shouldRetry = handler.afterSend(mockedResponse);
+
+        // Assert
+        assertFalse(shouldRetry);
     }
 
     private static Stream<Arguments> responseOtherThanUnauthorized() {

--- a/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
@@ -23,12 +23,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class UsernamePasswordHandlerTest {
-
     private final String repoId = "repoId";
     private final String username = "username";
     private final String password = "password";
     private final String baseUrl = "http://localhost:11211";
-    private final Request _request = new RequestImpl();
+    private final Request request = new RequestImpl();
 
     private HttpRequestHandler handler;
 
@@ -57,20 +56,20 @@ public class UsernamePasswordHandlerTest {
 
         // Act
         BeforeSendResult result = handler
-                .beforeSend(_request)
+                .beforeSend(request)
                 .join();
 
         // Assert
         assertNotNull(result);
         assertNull(result.getRegionalDomain());
-        assertTrue(_request
+        assertTrue(request
                 .headers()
                 .get("Authorization")
                 .contains("Bearer"));
-        assertNotNull(_request
+        assertNotNull(request
                 .headers()
                 .get("Authorization")
-                .substring(6, _request
+                .substring(6, request
                         .headers()
                         .get("Authorization")
                         .length() - 1));

--- a/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
@@ -57,7 +57,7 @@ public class UsernamePasswordHandlerTest {
 
         // Act
         BeforeSendResult result = handler
-                .beforeSendAsync(_request)
+                .beforeSend(_request)
                 .join();
 
         // Assert
@@ -85,7 +85,7 @@ public class UsernamePasswordHandlerTest {
 
         // Act
         handler
-                .afterSendAsync(mockedResponse)
+                .afterSend(mockedResponse)
                 .thenApply((shouldRetry) -> {
                     // Assert
                     assertEquals(true, shouldRetry);
@@ -102,7 +102,7 @@ public class UsernamePasswordHandlerTest {
 
         // Act
         handler
-                .afterSendAsync(mockedResponse)
+                .afterSend(mockedResponse)
                 .thenApply((shouldRetry) -> {
                     // Assert
                     assertEquals(false, shouldRetry);


### PR DESCRIPTION
In this PR, we converted all public APIs from using CompletableFuture to normal blocking calls. Reasons:

1. All of our customers use it in a blocking way (they just join() every CompletableFuture call).
2. Java's official async solution is through CompletableFutrue which under the hood uses a thread pool without an efficient way of releasing a thread when a task is blocked (so, no suspension point or yield, when a task is blocked, the thread is too). This isn't the same async provided by many other language implementations, such as .NET. Java 19 now has a preview feature called virtual threads that does allow efficient use of threads but it would be years for Java 8 (if it would ever happen) to have it. The current story of async really isn't ideal at all.
3. If our users want to use async, they can still do so with CompletableFuture, but because of 2, it isn't much useful for us to provide the APIs in async form.

So, in this PR, we did the following:

1. Convert all APIs into normal blocking calls.
2. Update unit and integration tests.

Currently all tests except the self-hosted tests are passing. I will update the PR when I get that part working.