### PR TITLE
Add custom deserializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>lf-api-client-core</artifactId>
   <packaging>jar</packaging>
   <name>Laserfiche API Client Core</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <url>https://github.com/Laserfiche/lf-api-client-core-java</url>
   <description>Java implementation of various foundational APIs for Laserfiche, including authorization APIs such as
     OAuth 2.0 flows for secure and easy access to Laserfiche APIs.

--- a/src/main/java/com/laserfiche/api/client/deserialization/TokenClientObjectMapper.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/TokenClientObjectMapper.java
@@ -4,17 +4,23 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import kong.unirest.GenericType;
 import kong.unirest.ObjectMapper;
+import org.threeten.bp.OffsetDateTime;
 
 import java.io.IOException;
 
 public class TokenClientObjectMapper implements ObjectMapper {
-    private com.fasterxml.jackson.databind.ObjectMapper jacksonMapper;
+    private final com.fasterxml.jackson.databind.ObjectMapper jacksonMapper;
 
     public TokenClientObjectMapper() {
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeserializer());
+
         jacksonMapper = JsonMapper
                 .builder()
+                .addModule(module)
                 .disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)


### PR DESCRIPTION
Add a custom deserializer to the ObjectMapper implementation so that it can also be used by the repository client library.