### PR TITLE
Add copyright header to .java files.

### DIFF
--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.apiserver;
 
 import com.laserfiche.api.client.model.CreateConnectionRequest;

--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClient.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.apiserver;
 

--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClientImpl.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClientImpl.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.apiserver;
 

--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClientImpl.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.apiserver;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/api/client/apiserver/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes to get access tokens for Laserfiche Self-Hosted.
  */

--- a/src/main/java/com/laserfiche/api/client/apiserver/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/package-info.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes to get access tokens for Laserfiche Self-Hosted.

--- a/src/main/java/com/laserfiche/api/client/deserialization/JwkDeserializer.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/JwkDeserializer.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.deserialization;
 

--- a/src/main/java/com/laserfiche/api/client/deserialization/JwkDeserializer.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/JwkDeserializer.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.deserialization;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/src/main/java/com/laserfiche/api/client/deserialization/OffsetDateTimeDeserializer.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/OffsetDateTimeDeserializer.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.deserialization;
 

--- a/src/main/java/com/laserfiche/api/client/deserialization/OffsetDateTimeDeserializer.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/OffsetDateTimeDeserializer.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.deserialization;
 
 import com.fasterxml.jackson.core.JacksonException;

--- a/src/main/java/com/laserfiche/api/client/deserialization/ProblemDetailsDeserializer.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/ProblemDetailsDeserializer.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.deserialization;
 

--- a/src/main/java/com/laserfiche/api/client/deserialization/ProblemDetailsDeserializer.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/ProblemDetailsDeserializer.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.deserialization;
 
 import com.laserfiche.api.client.model.ProblemDetails;

--- a/src/main/java/com/laserfiche/api/client/deserialization/TokenClientObjectMapper.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/TokenClientObjectMapper.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.deserialization;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/com/laserfiche/api/client/deserialization/TokenClientObjectMapper.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/TokenClientObjectMapper.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.deserialization;
 

--- a/src/main/java/com/laserfiche/api/client/deserialization/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/package-info.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides internal classes for deserialization.

--- a/src/main/java/com/laserfiche/api/client/deserialization/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/deserialization/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides internal classes for deserialization.
  */

--- a/src/main/java/com/laserfiche/api/client/httphandlers/BeforeSendResult.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/BeforeSendResult.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 /**

--- a/src/main/java/com/laserfiche/api/client/httphandlers/BeforeSendResult.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/BeforeSendResult.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HeaderKeyValue.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HeaderKeyValue.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 /**

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HeaderKeyValue.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HeaderKeyValue.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HeaderKeyValueImpl.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HeaderKeyValueImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 /**

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HeaderKeyValueImpl.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HeaderKeyValueImpl.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/Headers.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/Headers.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 import java.util.Collection;

--- a/src/main/java/com/laserfiche/api/client/httphandlers/Headers.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/Headers.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HeadersImpl.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HeadersImpl.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HeadersImpl.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HeadersImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 import java.util.*;

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 /**

--- a/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/HttpRequestHandler.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/OAuthClientCredentialsHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/OAuthClientCredentialsHandler.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 import com.laserfiche.api.client.model.AccessKey;

--- a/src/main/java/com/laserfiche/api/client/httphandlers/OAuthClientCredentialsHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/OAuthClientCredentialsHandler.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/Request.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/Request.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 /**

--- a/src/main/java/com/laserfiche/api/client/httphandlers/Request.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/Request.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/RequestImpl.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/RequestImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 /**

--- a/src/main/java/com/laserfiche/api/client/httphandlers/RequestImpl.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/RequestImpl.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/Response.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/Response.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 /**

--- a/src/main/java/com/laserfiche/api/client/httphandlers/Response.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/Response.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/ResponseImpl.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/ResponseImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 /**

--- a/src/main/java/com/laserfiche/api/client/httphandlers/ResponseImpl.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/ResponseImpl.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/UsernamePasswordHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/UsernamePasswordHandler.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 

--- a/src/main/java/com/laserfiche/api/client/httphandlers/UsernamePasswordHandler.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/UsernamePasswordHandler.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.httphandlers;
 
 import com.laserfiche.api.client.apiserver.TokenClient;

--- a/src/main/java/com/laserfiche/api/client/httphandlers/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes to modify HTTP requests and handle HTTP responses.
  */

--- a/src/main/java/com/laserfiche/api/client/httphandlers/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/httphandlers/package-info.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes to modify HTTP requests and handle HTTP responses.

--- a/src/main/java/com/laserfiche/api/client/model/AccessKey.java
+++ b/src/main/java/com/laserfiche/api/client/model/AccessKey.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 
 import com.fasterxml.jackson.databind.MapperFeature;

--- a/src/main/java/com/laserfiche/api/client/model/AccessKey.java
+++ b/src/main/java/com/laserfiche/api/client/model/AccessKey.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 

--- a/src/main/java/com/laserfiche/api/client/model/ApiException.java
+++ b/src/main/java/com/laserfiche/api/client/model/ApiException.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 
 import java.util.Map;

--- a/src/main/java/com/laserfiche/api/client/model/ApiException.java
+++ b/src/main/java/com/laserfiche/api/client/model/ApiException.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 

--- a/src/main/java/com/laserfiche/api/client/model/CreateConnectionRequest.java
+++ b/src/main/java/com/laserfiche/api/client/model/CreateConnectionRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/laserfiche/api/client/model/CreateConnectionRequest.java
+++ b/src/main/java/com/laserfiche/api/client/model/CreateConnectionRequest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 

--- a/src/main/java/com/laserfiche/api/client/model/GetAccessTokenResponse.java
+++ b/src/main/java/com/laserfiche/api/client/model/GetAccessTokenResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/laserfiche/api/client/model/GetAccessTokenResponse.java
+++ b/src/main/java/com/laserfiche/api/client/model/GetAccessTokenResponse.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 

--- a/src/main/java/com/laserfiche/api/client/model/ProblemDetails.java
+++ b/src/main/java/com/laserfiche/api/client/model/ProblemDetails.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;

--- a/src/main/java/com/laserfiche/api/client/model/ProblemDetails.java
+++ b/src/main/java/com/laserfiche/api/client/model/ProblemDetails.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 

--- a/src/main/java/com/laserfiche/api/client/model/SessionKeyInfo.java
+++ b/src/main/java/com/laserfiche/api/client/model/SessionKeyInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/laserfiche/api/client/model/SessionKeyInfo.java
+++ b/src/main/java/com/laserfiche/api/client/model/SessionKeyInfo.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.model;
 

--- a/src/main/java/com/laserfiche/api/client/model/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/model/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides model classes used by other packages.
  */

--- a/src/main/java/com/laserfiche/api/client/model/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/model/package-info.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides model classes used by other packages.

--- a/src/main/java/com/laserfiche/api/client/oauth/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/TokenClient.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.oauth;
 

--- a/src/main/java/com/laserfiche/api/client/oauth/TokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/TokenClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.oauth;
 
 import com.laserfiche.api.client.model.AccessKey;

--- a/src/main/java/com/laserfiche/api/client/oauth/TokenClientImpl.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/TokenClientImpl.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.oauth;
 

--- a/src/main/java/com/laserfiche/api/client/oauth/TokenClientImpl.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/TokenClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.oauth;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/api/client/oauth/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes to get access tokens for Laserfiche Cloud.
  */

--- a/src/main/java/com/laserfiche/api/client/oauth/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/oauth/package-info.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes to get access tokens for Laserfiche Cloud.

--- a/src/main/java/com/laserfiche/api/client/tokenclients/BaseTokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/tokenclients/BaseTokenClient.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.tokenclients;
 

--- a/src/main/java/com/laserfiche/api/client/tokenclients/BaseTokenClient.java
+++ b/src/main/java/com/laserfiche/api/client/tokenclients/BaseTokenClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.tokenclients;
 
 import com.laserfiche.api.client.deserialization.TokenClientObjectMapper;

--- a/src/main/java/com/laserfiche/api/client/tokenclients/TokenClientUtils.java
+++ b/src/main/java/com/laserfiche/api/client/tokenclients/TokenClientUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.tokenclients;
 

--- a/src/main/java/com/laserfiche/api/client/tokenclients/TokenClientUtils.java
+++ b/src/main/java/com/laserfiche/api/client/tokenclients/TokenClientUtils.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.tokenclients;
 
 import com.laserfiche.api.client.model.AccessKey;

--- a/src/main/java/com/laserfiche/api/client/tokenclients/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/tokenclients/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes common to all token clients.
  */

--- a/src/main/java/com/laserfiche/api/client/tokenclients/package-info.java
+++ b/src/main/java/com/laserfiche/api/client/tokenclients/package-info.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes common to all token clients.

--- a/src/test/java/com/laserfiche/api/client/integration/BaseTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/BaseTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.integration;
 

--- a/src/test/java/com/laserfiche/api/client/integration/BaseTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/BaseTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.integration;
 
 import com.laserfiche.api.client.model.AccessKey;

--- a/src/test/java/com/laserfiche/api/client/integration/OAuthClientCredentialsHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/OAuthClientCredentialsHandlerTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.integration;
 
 import com.laserfiche.api.client.httphandlers.*;

--- a/src/test/java/com/laserfiche/api/client/integration/OAuthClientCredentialsHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/OAuthClientCredentialsHandlerTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.integration;
 

--- a/src/test/java/com/laserfiche/api/client/integration/TokenClientImplTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/TokenClientImplTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.integration;
 
 import com.laserfiche.api.client.model.ApiException;

--- a/src/test/java/com/laserfiche/api/client/integration/TokenClientImplTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/TokenClientImplTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.integration;
 

--- a/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.integration;
 
 import com.laserfiche.api.client.httphandlers.*;

--- a/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/integration/UsernamePasswordHandlerTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.integration;
 

--- a/src/test/java/com/laserfiche/api/client/unit/AccessKeyTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/AccessKeyTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 
 import com.laserfiche.api.client.model.AccessKey;

--- a/src/test/java/com/laserfiche/api/client/unit/AccessKeyTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/AccessKeyTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 

--- a/src/test/java/com/laserfiche/api/client/unit/ApiExceptionTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/ApiExceptionTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 

--- a/src/test/java/com/laserfiche/api/client/unit/ApiExceptionTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/ApiExceptionTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 
 import com.laserfiche.api.client.model.ApiException;

--- a/src/test/java/com/laserfiche/api/client/unit/HeadersImplTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/HeadersImplTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 
 import com.laserfiche.api.client.httphandlers.HeaderKeyValue;

--- a/src/test/java/com/laserfiche/api/client/unit/HeadersImplTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/HeadersImplTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 

--- a/src/test/java/com/laserfiche/api/client/unit/OAuthClientCredentialsHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/OAuthClientCredentialsHandlerTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 
 import com.laserfiche.api.client.httphandlers.HttpRequestHandler;

--- a/src/test/java/com/laserfiche/api/client/unit/OAuthClientCredentialsHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/OAuthClientCredentialsHandlerTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 

--- a/src/test/java/com/laserfiche/api/client/unit/ProblemDetailsDeserializerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/ProblemDetailsDeserializerTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/test/java/com/laserfiche/api/client/unit/ProblemDetailsDeserializerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/ProblemDetailsDeserializerTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 

--- a/src/test/java/com/laserfiche/api/client/unit/ProblemDetailsTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/ProblemDetailsTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 
 import com.laserfiche.api.client.model.ProblemDetails;

--- a/src/test/java/com/laserfiche/api/client/unit/ProblemDetailsTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/ProblemDetailsTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 

--- a/src/test/java/com/laserfiche/api/client/unit/TokenClientUtilsTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/TokenClientUtilsTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 
 import com.laserfiche.api.client.integration.BaseTest;

--- a/src/test/java/com/laserfiche/api/client/unit/TokenClientUtilsTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/TokenClientUtilsTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 

--- a/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) Laserfiche
+// Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 

--- a/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
+++ b/src/test/java/com/laserfiche/api/client/unit/UsernamePasswordHandlerTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.api.client.unit;
 
 import com.laserfiche.api.client.apiserver.TokenClient;


### PR DESCRIPTION
Insert the following copyright header at the top of all `*.java` files.
```
// Copyright (c) Laserfiche.
// Licensed under the MIT License. See LICENSE in the project root for license information.
```