### PR TITLE
Retrieve header value by lower-case name

### DIFF
--- a/src/main/java/com/laserfiche/api/client/model/ProblemDetails.java
+++ b/src/main/java/com/laserfiche/api/client/model/ProblemDetails.java
@@ -11,6 +11,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -206,11 +207,7 @@ public class ProblemDetails {
     }
 
     private static String getHeaderValue(Map<String, String> headers, String headerName) {
-        Map<String, String> headersInLowerCase =
-                headers.entrySet().stream()
-                        .collect(
-                                HashMap::new,
-                                (m,v)->m.put(v.getKey().toLowerCase(), v.getValue()), HashMap::putAll);
-        return headersInLowerCase.getOrDefault(headerName.toLowerCase(), null);
+        Optional<Map.Entry<String, String>> result = headers.entrySet().stream().filter(entry -> entry.getKey().equalsIgnoreCase(headerName)).findFirst();
+        return result.map(Map.Entry::getValue).orElse(null);
     }
 }

--- a/src/main/java/com/laserfiche/api/client/model/ProblemDetails.java
+++ b/src/main/java/com/laserfiche/api/client/model/ProblemDetails.java
@@ -208,10 +208,9 @@ public class ProblemDetails {
     private static String getHeaderValue(Map<String, String> headers, String headerName) {
         Map<String, String> headersInLowerCase =
                 headers.entrySet().stream()
-                        .collect(Collectors.toMap(
-                                e -> e.getKey().toLowerCase(),
-                                Map.Entry::getValue
-                        ));
+                        .collect(
+                                HashMap::new,
+                                (m,v)->m.put(v.getKey().toLowerCase(), v.getValue()), HashMap::putAll);
         return headersInLowerCase.getOrDefault(headerName.toLowerCase(), null);
     }
 }

--- a/src/main/java/com/laserfiche/api/client/model/ProblemDetails.java
+++ b/src/main/java/com/laserfiche/api/client/model/ProblemDetails.java
@@ -187,9 +187,12 @@ public class ProblemDetails {
 
         String errorMessage = null;
         if (headers != null) {
-            problemDetails.setOperationId(headers.getOrDefault(OPERATION_ID_HEADER, null));
+            String operationId = headers.getOrDefault(OPERATION_ID_HEADER,
+                    headers.getOrDefault(OPERATION_ID_HEADER.toLowerCase(), null));
+            problemDetails.setOperationId(operationId);
 
-            String headerErrorMessage = headers.getOrDefault(API_SERVER_ERROR_MESSAGE_HEADER, null);
+            String headerErrorMessage = headers.getOrDefault(API_SERVER_ERROR_MESSAGE_HEADER,
+                    headers.getOrDefault(API_SERVER_ERROR_MESSAGE_HEADER.toLowerCase(), null));
             if (headerErrorMessage != null) {
                 try {
                     errorMessage = URLDecoder.decode(headerErrorMessage, StandardCharsets.UTF_8.name());


### PR DESCRIPTION
When retrieving custom header value, also try getting by lower case name.

The integration test <code>getDocumentContentType_Returns_Valid_Error_Message_ForInvalidRepoId</code> has recently failed because, for some reason not yet known, the <code>X-APIServer-Error</code> header sent by APIServer is received as <code>x-apiserver-error</code>. 

For example, as mentioned in [this post](https://stackoverflow.com/questions/64967098/how-to-get-nginx-to-add-a-header-without-converting-it-to-lowercase), it is possible that the header names are changed to lowercase, e.g. by nginx. So, the receiver should handle this case too.