### PR TITLE
Add null check.

### DIFF
--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClientImpl.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClientImpl.java
@@ -8,7 +8,9 @@ import com.laserfiche.api.client.model.CreateConnectionRequest;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.api.client.model.SessionKeyInfo;
 import com.laserfiche.api.client.tokenclients.BaseTokenClient;
+import kong.unirest.HttpRequestWithBody;
 import kong.unirest.HttpResponse;
+import kong.unirest.MultipartBody;
 import kong.unirest.json.JSONObject;
 
 import java.util.HashMap;
@@ -36,17 +38,26 @@ public class TokenClientImpl extends BaseTokenClient implements TokenClient {
         Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"},
                 new Object[]{repositoryId});
 
-        HttpResponse<Object> httpResponse = httpClient
+        MultipartBody request = httpClient
                 .post(baseUrl + "/v1/Repositories/{repoId}/Token")
                 .routeParam(pathParameters)
                 .header("Accept", "application/json")
                 .header("Content-Type", "application/x-www-form-urlencoded")
-                .field("grant_type", "password")
-                .field("username", body
-                        .getUsername())
-                .field("password", body
-                        .getPassword())
-                .asObject(Object.class);
+                .field("grant_type", "password");
+        if (body != null) {
+            if (body.getUsername() != null) {
+                request = request.field("username", body
+                        .getUsername());
+            }
+            if (body.getPassword() != null) {
+                request = request.field("password", body
+                        .getPassword());
+            }
+        }
+
+       HttpResponse<Object> httpResponse = request.asObject(Object.class);
+
+
         Map<String, String> headersMap = getHeadersMap(httpResponse);
         if (httpResponse.getStatus() == 200) {
             try {

--- a/src/main/java/com/laserfiche/api/client/apiserver/TokenClientImpl.java
+++ b/src/main/java/com/laserfiche/api/client/apiserver/TokenClientImpl.java
@@ -8,7 +8,6 @@ import com.laserfiche.api.client.model.CreateConnectionRequest;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.api.client.model.SessionKeyInfo;
 import com.laserfiche.api.client.tokenclients.BaseTokenClient;
-import kong.unirest.HttpRequestWithBody;
 import kong.unirest.HttpResponse;
 import kong.unirest.MultipartBody;
 import kong.unirest.json.JSONObject;

--- a/src/main/java/com/laserfiche/api/client/tokenclients/TokenClientUtils.java
+++ b/src/main/java/com/laserfiche/api/client/tokenclients/TokenClientUtils.java
@@ -44,6 +44,10 @@ public class TokenClientUtils {
      * @return Bearer header.
      */
     public static String createBearer(String servicePrincipalKey, AccessKey accessKey) {
+        if (accessKey.getJwk() == null) {
+            return null;
+        }
+
         // Prepare JWK
         ECKey jwk = accessKey.getJwk().toECKey();
 


### PR DESCRIPTION
Add null check to prevent methods throwing `NullPointerException`.
This was detected by unit tests auto-generated by Randoop. It is generally considered a bad practice for a method to be called by non-null arguments but throw `NullPointerException`. Below, is one of these tests:

```
    @Test
    public void test001() throws Throwable {
        if (debug)
            System.out.format("%n%s%n", "ErrorTest0.test001");
        com.laserfiche.api.client.apiserver.TokenClientImpl tokenClientImpl1 = new com.laserfiche.api.client.apiserver.TokenClientImpl("");
        com.laserfiche.api.client.model.CreateConnectionRequest createConnectionRequest3 = new com.laserfiche.api.client.model.CreateConnectionRequest();
        java.lang.String str4 = createConnectionRequest3.getPassword();
        createConnectionRequest3.setUsername("https://signin.hi!/oauth/");
        // during test generation this statement threw an exception of type java.lang.NullPointerException in error
        com.laserfiche.api.client.model.SessionKeyInfo sessionKeyInfo7 = tokenClientImpl1.createAccessToken("", createConnectionRequest3);
    }
```

