### PR TITLE
fix(security): bump jackson-databind to 2.18.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      pull-requests: write
 
     env:
       ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,10 @@ jobs:
   build-n-test:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      checks: write
+
     env:
       ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
       SERVICE_PRINCIPAL_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.5
+
+### Maintenance
+
+- Update `jackson-databind` dependency due to vulnerability
+
 ## 2.2.4
 
 ### Maintenance

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>lf-api-client-core</artifactId>
   <packaging>jar</packaging>
   <name>Laserfiche API Client Core</name>
-  <version>2.2.0</version>
+  <version>2.2.5</version>
   <url>https://github.com/Laserfiche/lf-api-client-core-java</url>
   <description>Java implementation of various foundational APIs for Laserfiche, including authorization APIs such as
     OAuth 2.0 flows for secure and easy access to Laserfiche APIs.

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>2.0.0</swagger-core-version>
-    <jackson-version>2.18.2</jackson-version>
+    <jackson-version>2.18.8</jackson-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>


### PR DESCRIPTION
Bumps the shared `jackson-version` property from 2.18.2 to 2.18.8 to remediate two Veracode-flagged CVEs in jackson-databind:

- CVE-2026-54512 — PolymorphicTypeValidator bypass via generic type parameters
- CVE-2026-54513 — PolymorphicTypeValidator bypass via array component types (allowIfSubTypeIsArray)

Both are fixed upstream in 2.18.8.

Fixes #679083
Fixes #679084